### PR TITLE
Load: 内存控制 ver0.1

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -1090,6 +1090,8 @@ public class IoTDBConfig {
   /** Load related */
   private int maxLoadingTimeseriesNumber = 2000;
 
+  // TODO: remove loadMemoryTotalSizeFromQueryInBytes after introducing queryEngine memory manager
+  private long loadMemoryTotalSizeFromQueryInBytes = 200 * 1024 * 1024L;
   private long initLoadMemoryTotalSizeInBytes = 100 * 1024 * 1024L; // 100MB
   private long loadMemoryAllocateRetryIntervalMs = 1000;
   private int loadMemoryAllocateMaxRetries = 10;
@@ -3727,6 +3729,14 @@ public class IoTDBConfig {
 
   public int getModeMapSizeThreshold() {
     return modeMapSizeThreshold;
+  }
+
+  public long getLoadMemoryTotalSizeFromQueryInBytes() {
+    return loadMemoryTotalSizeFromQueryInBytes;
+  }
+
+  public void setLoadMemoryTotalSizeFromQueryInBytes(long loadMemoryTotalSizeFromQueryInBytes) {
+    this.loadMemoryTotalSizeFromQueryInBytes = loadMemoryTotalSizeFromQueryInBytes;
   }
 
   public long getInitLoadMemoryTotalSizeInBytes() {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/conf/IoTDBConfig.java
@@ -174,8 +174,6 @@ public class IoTDBConfig {
   /** The proportion of write memory for loading TsFile */
   private double loadTsFileProportion = 0.125;
 
-  private int maxLoadingTimeseriesNumber = 2000;
-
   /**
    * If memory cost of data region increased more than proportion of {@linkplain
    * IoTDBConfig#getAllocateMemoryForStorageEngine()}*{@linkplain
@@ -1088,6 +1086,14 @@ public class IoTDBConfig {
   private int maxSizePerBatch = 16 * 1024 * 1024;
   private int maxPendingBatchesNum = 5;
   private double maxMemoryRatioForQueue = 0.6;
+
+  /** Load related */
+  private int maxLoadingTimeseriesNumber = 2000;
+
+  private long initLoadMemoryTotalSizeInBytes = 100 * 1024 * 1024L; // 100MB
+  private long loadMemoryAllocateRetryIntervalMs = 1000;
+  private int loadMemoryAllocateMaxRetries = 10;
+  private long loadMemoryAllocateMinSizeInBytes = 32;
 
   /** Pipe related */
   /** initialized as empty, updated based on the latest `systemDir` during querying */
@@ -3269,14 +3275,6 @@ public class IoTDBConfig {
     return loadTsFileProportion;
   }
 
-  public int getMaxLoadingTimeseriesNumber() {
-    return maxLoadingTimeseriesNumber;
-  }
-
-  public void setMaxLoadingTimeseriesNumber(int maxLoadingTimeseriesNumber) {
-    this.maxLoadingTimeseriesNumber = maxLoadingTimeseriesNumber;
-  }
-
   public static String getEnvironmentVariables() {
     return "\n\t"
         + IoTDBConstant.IOTDB_HOME
@@ -3729,6 +3727,46 @@ public class IoTDBConfig {
 
   public int getModeMapSizeThreshold() {
     return modeMapSizeThreshold;
+  }
+
+  public long getInitLoadMemoryTotalSizeInBytes() {
+    return initLoadMemoryTotalSizeInBytes;
+  }
+
+  public void setInitLoadMemoryTotalSizeInBytes(long initLoadMemoryTotalSizeInBytes) {
+    this.initLoadMemoryTotalSizeInBytes = initLoadMemoryTotalSizeInBytes;
+  }
+
+  public int getMaxLoadingTimeseriesNumber() {
+    return maxLoadingTimeseriesNumber;
+  }
+
+  public void setMaxLoadingTimeseriesNumber(int maxLoadingTimeseriesNumber) {
+    this.maxLoadingTimeseriesNumber = maxLoadingTimeseriesNumber;
+  }
+
+  public long getLoadMemoryAllocateRetryIntervalMs() {
+    return loadMemoryAllocateRetryIntervalMs;
+  }
+
+  public void setLoadMemoryAllocateRetryIntervalMs(long loadMemoryAllocateRetryIntervalMs) {
+    this.loadMemoryAllocateRetryIntervalMs = loadMemoryAllocateRetryIntervalMs;
+  }
+
+  public int getLoadMemoryAllocateMaxRetries() {
+    return loadMemoryAllocateMaxRetries;
+  }
+
+  public void setLoadMemoryAllocateMaxRetries(int loadMemoryAllocateMaxRetries) {
+    this.loadMemoryAllocateMaxRetries = loadMemoryAllocateMaxRetries;
+  }
+
+  public long getLoadMemoryAllocateMinSizeInBytes() {
+    return loadMemoryAllocateMinSizeInBytes;
+  }
+
+  public void setLoadMemoryAllocateMinSizeInBytes(long loadMemoryAllocateMinSizeInBytes) {
+    this.loadMemoryAllocateMinSizeInBytes = loadMemoryAllocateMinSizeInBytes;
   }
 
   public void setPipeReceiverFileDirs(String[] pipeReceiverFileDirs) {

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/load/analyze/LoadTsfileAnalyzer.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/load/analyze/LoadTsfileAnalyzer.java
@@ -45,6 +45,7 @@ import org.apache.iotdb.db.protocol.session.SessionManager;
 import org.apache.iotdb.db.queryengine.common.MPPQueryContext;
 import org.apache.iotdb.db.queryengine.common.schematree.DeviceSchemaInfo;
 import org.apache.iotdb.db.queryengine.common.schematree.ISchemaTree;
+import org.apache.iotdb.db.queryengine.load.memory.DeviceToTimeseriesSchemasMap;
 import org.apache.iotdb.db.queryengine.plan.Coordinator;
 import org.apache.iotdb.db.queryengine.plan.analyze.Analysis;
 import org.apache.iotdb.db.queryengine.plan.analyze.IPartitionFetcher;
@@ -252,8 +253,8 @@ public class LoadTsfileAnalyzer {
   private final class SchemaAutoCreatorAndVerifier {
 
     private final Map<String, Boolean> tsfileDevice2IsAligned = new HashMap<>();
-    private final Map<String, Set<MeasurementSchema>> currentBatchDevice2TimeseriesSchemas =
-        new HashMap<>();
+    private final DeviceToTimeseriesSchemasMap currentBatchDevice2TimeseriesSchemas =
+        DeviceToTimeseriesSchemasMap.getInstance();
 
     private final Set<PartialPath> alreadySetDatabases = new HashSet<>();
 
@@ -304,14 +305,13 @@ public class LoadTsfileAnalyzer {
             }
             final Pair<CompressionType, TSEncoding> compressionEncodingPair =
                 reader.readTimeseriesCompressionTypeAndEncoding(timeseriesMetadata);
-            currentBatchDevice2TimeseriesSchemas
-                .computeIfAbsent(device, o -> new HashSet<>())
-                .add(
-                    new MeasurementSchema(
-                        timeseriesMetadata.getMeasurementId(),
-                        dataType,
-                        compressionEncodingPair.getRight(),
-                        compressionEncodingPair.getLeft()));
+            currentBatchDevice2TimeseriesSchemas.add(
+                device,
+                new MeasurementSchema(
+                    timeseriesMetadata.getMeasurementId(),
+                    dataType,
+                    compressionEncodingPair.getRight(),
+                    compressionEncodingPair.getLeft()));
 
             tsfileDevice2IsAligned.putIfAbsent(device, false);
           }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/load/exception/LoadRuntimeOutOfMemoryException.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/load/exception/LoadRuntimeOutOfMemoryException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.load.exception;
+
+public class LoadRuntimeOutOfMemoryException extends RuntimeException {
+  public LoadRuntimeOutOfMemoryException(String message) {
+    super(message);
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/load/memory/DeviceToTimeseriesSchemasMap.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/load/memory/DeviceToTimeseriesSchemasMap.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.load.memory;
+
+import org.apache.iotdb.db.conf.IoTDBDescriptor;
+import org.apache.iotdb.db.queryengine.load.memory.block.LoadMemoryBlock;
+import org.apache.iotdb.tsfile.write.schema.MeasurementSchema;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class DeviceToTimeseriesSchemasMap {
+  private final LoadTsFileMemoryManager loadTsFileMemoryManager =
+      LoadTsFileMemoryManager.getInstance();
+
+  private final LoadMemoryBlock block;
+
+  private long totalMemorySizeInBytes =
+      IoTDBDescriptor.getInstance().getConfig().getInitLoadMemoryTotalSizeInBytes() / 2;
+  private long usedMemorySizeInBytes = 0;
+
+  private final Map<String, Set<MeasurementSchema>> currentBatchDevice2TimeseriesSchemas =
+      new HashMap<>();
+
+  // true if the memory is still enough and the schema is added successfully, false when it is out
+  // of memory.
+  public boolean add(String device, MeasurementSchema measurementSchema) {
+    currentBatchDevice2TimeseriesSchemas
+        .computeIfAbsent(device, k -> new HashSet<>())
+        .add(measurementSchema);
+
+    usedMemorySizeInBytes += measurementSchema.serializedSize();
+    return usedMemorySizeInBytes <= totalMemorySizeInBytes;
+  }
+
+  public void clear() {
+    currentBatchDevice2TimeseriesSchemas.clear();
+    usedMemorySizeInBytes = 0;
+  }
+
+  public boolean isEmpty() {
+    return currentBatchDevice2TimeseriesSchemas.isEmpty();
+  }
+
+  public Set<Map.Entry<String, Set<MeasurementSchema>>> entrySet() {
+    return currentBatchDevice2TimeseriesSchemas.entrySet();
+  }
+
+  public Set<String> keySet() {
+    return currentBatchDevice2TimeseriesSchemas.keySet();
+  }
+
+  public void distory() {
+    currentBatchDevice2TimeseriesSchemas.clear();
+    totalMemorySizeInBytes = 0;
+    usedMemorySizeInBytes = 0;
+    loadTsFileMemoryManager.release(block);
+  }
+
+  ///////////////////////////// SINGLETON /////////////////////////////
+  private DeviceToTimeseriesSchemasMap() {
+    block = loadTsFileMemoryManager.forceAllocate(totalMemorySizeInBytes);
+  }
+
+  public static DeviceToTimeseriesSchemasMap getInstance() {
+    return LoadTsFileAnalyzerMemoryManagerHolder.INSTANCE;
+  }
+
+  public static class LoadTsFileAnalyzerMemoryManagerHolder {
+    private static final DeviceToTimeseriesSchemasMap INSTANCE = new DeviceToTimeseriesSchemasMap();
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/load/memory/LoadTsFileSchedulerCacheMemoryManager.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/load/memory/LoadTsFileSchedulerCacheMemoryManager.java
@@ -19,10 +19,56 @@
 
 package org.apache.iotdb.db.queryengine.load.memory;
 
-public class LoadTsFileSchedulerCacheMemoryManager {
-  public void allocateMemory(long memoryBudgetInBytes) throws Exception {}
+import org.apache.iotdb.common.rpc.thrift.TEndPoint;
+import org.apache.iotdb.db.queryengine.plan.planner.plan.node.load.LoadTsFileNode;
 
-  public long tryAllocateMemory(long memoryBudgetInBytes) throws Exception {
-    return 0;
+import java.util.HashMap;
+import java.util.Map;
+
+// TODO: not complete
+public class LoadTsFileSchedulerCacheMemoryManager {
+
+  // todo: set init value
+  private long totalMemorySizeInBytes;
+  private long usedMemorySizeInBytes = 0;
+
+  private final Map<TEndPoint, LoadTsFileNode> dispatchCache;
+
+  public void add(TEndPoint endPoint, LoadTsFileNode loadTsFileNode) {
+    dispatchCache.put(endPoint, loadTsFileNode);
+  }
+
+  public LoadTsFileNode get(TEndPoint endPoint) {
+    return dispatchCache.get(endPoint);
+  }
+
+  public void remove(TEndPoint endPoint) {
+    dispatchCache.remove(endPoint);
+  }
+
+  public boolean contains(TEndPoint endPoint) {
+    return dispatchCache.containsKey(endPoint);
+  }
+
+  public void clear() {
+    dispatchCache.clear();
+  }
+
+  public boolean isEmpty() {
+    return dispatchCache.isEmpty();
+  }
+
+  ///////////////////////////// SINGLETON /////////////////////////////
+  private LoadTsFileSchedulerCacheMemoryManager() {
+    dispatchCache = new HashMap<>();
+  }
+
+  public static LoadTsFileSchedulerCacheMemoryManager getInstance() {
+    return LoadTsFileSchedulerCacheMemoryManagerHolder.INSTANCE;
+  }
+
+  public static class LoadTsFileSchedulerCacheMemoryManagerHolder {
+    private static final LoadTsFileSchedulerCacheMemoryManager INSTANCE =
+        new LoadTsFileSchedulerCacheMemoryManager();
   }
 }

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/load/memory/block/AbstractMemoryBlock.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/load/memory/block/AbstractMemoryBlock.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.load.memory.block;
+
+import org.apache.iotdb.db.queryengine.load.memory.LoadTsFileMemoryManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+
+public abstract class AbstractMemoryBlock implements AutoCloseable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractMemoryBlock.class);
+
+  protected final LoadTsFileMemoryManager loadMemoryManager = LoadTsFileMemoryManager.getInstance();
+
+  private final AtomicLong memoryUsageInBytes = new AtomicLong(0);
+
+  private final ReentrantLock lock = new ReentrantLock();
+
+  private volatile boolean isReleased = false;
+
+  public AbstractMemoryBlock(long memoryUsageInBytes) {
+    this.memoryUsageInBytes.set(memoryUsageInBytes);
+  }
+
+  protected abstract void releaseMemory();
+
+  public long getMemoryUsageInBytes() {
+    return memoryUsageInBytes.get();
+  }
+
+  public boolean isReleased() {
+    return isReleased;
+  }
+
+  public void markAsReleased() {
+    isReleased = true;
+  }
+
+  @Override
+  public void close() {
+    while (true) {
+      try {
+        if (lock.tryLock(50, TimeUnit.MICROSECONDS)) {
+          try {
+            releaseMemory();
+            break;
+          } finally {
+            lock.unlock();
+          }
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        LOGGER.warn("Interrupted while waiting for the lock.", e);
+      }
+    }
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/load/memory/block/LoadMemoryBlock.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/load/memory/block/LoadMemoryBlock.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.load.memory.block;
+
+public class LoadMemoryBlock extends AbstractMemoryBlock {
+  private final QueryMemoryBlock block;
+
+  public LoadMemoryBlock(long memoryUsageInBytes, QueryMemoryBlock queryBlock) {
+    super(memoryUsageInBytes);
+    block = queryBlock;
+  }
+
+  public QueryMemoryBlock getQueryMemoryBlock() {
+    return block;
+  }
+
+  @Override
+  protected void releaseMemory() {
+    loadMemoryManager.release(this);
+  }
+}

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/load/memory/block/QueryMemoryBlock.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/queryengine/load/memory/block/QueryMemoryBlock.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iotdb.db.queryengine.load.memory.block;
+
+public class QueryMemoryBlock extends AbstractMemoryBlock {
+  public QueryMemoryBlock(long memoryUsageInBytes) {
+    super(memoryUsageInBytes);
+  }
+
+  @Override
+  protected void releaseMemory() {
+    loadMemoryManager.releaseFromQuery(this);
+  }
+}

--- a/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReaderTimeseriesMetadataIterator.java
+++ b/iotdb-core/tsfile/src/main/java/org/apache/iotdb/tsfile/read/TsFileSequenceReaderTimeseriesMetadataIterator.java
@@ -39,7 +39,7 @@ import java.util.NoSuchElementException;
 public class TsFileSequenceReaderTimeseriesMetadataIterator
     implements Iterator<Map<String, List<TimeseriesMetadata>>> {
 
-  private static final int MAX_TIMESERIES_METADATA_COUNT = 2000;
+  private static final int MAX_TIMESERIES_METADATA_COUNT = 4000;
   private final TsFileSequenceReader reader;
   private final boolean needChunkMetadata;
   private ByteBuffer currentBuffer = null;


### PR DESCRIPTION
## Description
内存控制核心类 `LoadTsFileMemoryManager`， 向上（查询模块）提供`allocatedFromQuery` 和 `releaseFromQuery` 两个接口，向下（load模块）提供`forceAllocate`和`tryAllocate`两个接口

analyzer部分内存控制类 `DeviceToTimeseriesSchemasMap`, 其中封装了`Map<String, Set<MeasurementSchema>> currentBatchDevice2TimeseriesSchemas` ,向外提供 add(),isEmpty(),clear()等接口供TsFileAnalyzer调用，主要在add方法中添加计算内存流程

memoryBlock 是调用者申请内存后得到的内存块，其中包含申请到的内存大小，以及标记是否已释放的变量等。`QueryMemoryBlock`是向查询模块申请得到的内存块，`LoadMemoryBlock`是向 load 模块提供的内存块，申请到的 QueryMemoryBlock 会塞到相应的LoadMemoryBlock返回给load，其目的是当load模块用完内存块需要释放时，查询模块相应的内存也需要被释放。

未完成部分：
LoadTsFileSchedulerCacheMemoryManager

